### PR TITLE
Update gitignore and add 'httr' in DESCRIPTION file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
+*.Rproj

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,8 @@ Imports:
   tidyr,
   readr,
   lubridate,
-  ggplot2
+  ggplot2,
+  httr
 Suggests:
     testthat
 RoxygenNote: 5.0.1


### PR DESCRIPTION
I really should have had this as seperate pull requests but my git skills are not 100%.  

This pull request does two things:
1.  Add "*.Rproj" to the gitignore file so I can add an Rstudio project to the development version and others can do similarly. 
2. Adds httr to the DESCRIPTION file so get_gtfs() will be able to use GET(). 

Happy to make my first contribution. 
